### PR TITLE
Change to call the method in the super class on the _on_screen_resume  method

### DIFF
--- a/src/pilgrim/ui/screens/diary_list_screen.py
+++ b/src/pilgrim/ui/screens/diary_list_screen.py
@@ -216,6 +216,7 @@ class DiaryListScreen(Screen):
             self.notify(f"Creation canceled...")
 
     def _on_screen_resume(self) -> None:
+        super()._on_screen_resume()
         self.refresh_diaries()
 
     def action_edit_selected_diary(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen resume behavior in the diary list to ensure all expected updates and actions occur when returning to the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->