### PR TITLE
Fix the photo edit to properly pass the original photo hash that was missing

### DIFF
--- a/src/pilgrim/ui/screens/edit_entry_screen.py
+++ b/src/pilgrim/ui/screens/edit_entry_screen.py
@@ -611,7 +611,8 @@ class EditEntryScreen(Screen):
                 addition_date=original_photo.addition_date,
                 caption=photo_data["caption"],
                 entries=original_photo.entries if original_photo.entries is not None else [],
-                id=original_photo.id
+                id=original_photo.id,
+                photo_hash=original_photo.photo_hash,
             )
 
             result = photo_service.update(original_photo, updated_photo)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that photo updates now correctly preserve the original photo's unique identifier, preventing potential issues with photo recognition or duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->