### PR TITLE
Refactor the edit and add photo modal and remove the hashing methods out of the modals

### DIFF
--- a/src/pilgrim/ui/screens/modals/add_photo_modal.py
+++ b/src/pilgrim/ui/screens/modals/add_photo_modal.py
@@ -15,12 +15,6 @@ class AddPhotoModal(Screen):
         self.result = None
         self.created_photo = None
 
-    def _generate_photo_hash(self, photo_data: dict) -> str:
-        """Generate a short, unique hash for a photo"""
-        # Use temporary data for hash generation
-        unique_string = f"{photo_data['name']}_{photo_data.get('photo_id', 0)}_new"
-        hash_object = hashlib.md5(unique_string.encode())
-        return hash_object.hexdigest()[:8]
 
     def compose(self) -> ComposeResult:
         yield Container(
@@ -82,13 +76,9 @@ class AddPhotoModal(Screen):
 
             if new_photo:
                 self.created_photo = new_photo
-                # Generate hash for the new photo
-                photo_hash = self._generate_photo_hash({
-                    "name": new_photo.name,
-                    "photo_id": new_photo.id
-                })
+
                 
-                self.notify(f"Photo '{new_photo.name}' added successfully!\nHash: {photo_hash}\nReference: \\[\\[photo:{new_photo.name}:{photo_hash}\\]\\]", 
+                self.notify(f"Photo '{new_photo.name}' added successfully!\nHash: {new_photo.photo_hash[:8]}\nReference: \\[\\[photo:{new_photo.name}:{new_photo.photo_hash[:8]}\\]\\]",
                            severity="information", timeout=5)
                 
                 # Return the created photo data to the calling screen
@@ -97,7 +87,7 @@ class AddPhotoModal(Screen):
                     "name": photo_data["name"],
                     "caption": photo_data["caption"],
                     "photo_id": new_photo.id,
-                    "hash": photo_hash
+                    "hash": new_photo.photo_hash
                 }
                 self.dismiss(self.result)
             else:

--- a/src/pilgrim/ui/screens/modals/edit_photo_modal.py
+++ b/src/pilgrim/ui/screens/modals/edit_photo_modal.py
@@ -12,15 +12,11 @@ class EditPhotoModal(Screen):
         self.photo = photo
         self.result = None
 
-    def _generate_photo_hash(self, photo: Photo) -> str:
-        """Generate a short, unique hash for a photo"""
-        unique_string = f"{photo.name}_{photo.id}_{photo.addition_date}"
-        hash_object = hashlib.md5(unique_string.encode())
-        return hash_object.hexdigest()[:8]
+
 
     def compose(self) -> ComposeResult:
         # Generate hash for this photo
-        photo_hash = self._generate_photo_hash(self.photo)
+        photo_hash = None
         
         yield Container(
             Static("✏️ Edit Photo", classes="EditPhotoModal-Title"),
@@ -45,10 +41,9 @@ class EditPhotoModal(Screen):
                 id="caption-input", 
                 classes="EditPhotoModal-Input"
             ),
-            Static(f"🔗 Photo Hash: {photo_hash}", classes="EditPhotoModal-Hash"),
+            Static(f"🔗 Photo Hash: {self.photo.photo_hash[:8]}", classes="EditPhotoModal-Hash"),
             Static("Reference formats:", classes="EditPhotoModal-Label"),
-            Static(f"\\[\\[photo:{self.photo.name}:{photo_hash}\\]\\]", classes="EditPhotoModal-Reference"),
-            Static(f"\\[\\[photo::{photo_hash}\\]\\]", classes="EditPhotoModal-Reference"),
+            Static(f"\\[\\[photo::{self.photo.photo_hash[:8]}\\]\\]", classes="EditPhotoModal-Reference"),
             Horizontal(
                 Button("Save Changes", id="save-button", classes="EditPhotoModal-Button"),
                 Button("Cancel", id="cancel-button", classes="EditPhotoModal-Button"),

--- a/src/pilgrim/ui/screens/modals/edit_photo_modal.py
+++ b/src/pilgrim/ui/screens/modals/edit_photo_modal.py
@@ -3,7 +3,7 @@ from textual.screen import Screen
 from textual.widgets import Static, Input, Button
 from textual.containers import Container, Horizontal
 from pilgrim.models.photo import Photo
-import hashlib
+
 
 class EditPhotoModal(Screen):
     """Modal for editing an existing photo (name and caption only)"""
@@ -16,7 +16,7 @@ class EditPhotoModal(Screen):
 
     def compose(self) -> ComposeResult:
         # Generate hash for this photo
-        photo_hash = None
+
         
         yield Container(
             Static("✏️ Edit Photo", classes="EditPhotoModal-Title"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated photo modals to use the existing photo hash property for display and notifications, removing internal hash generation logic. The photo hash shown in the interface now directly reflects the stored value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->