### PR TITLE
Add the tests for the new methods of deleting

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
+from datetime import datetime
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from pilgrim.models.entry import Entry
 from pilgrim.database import Base
 from pilgrim.models.travel_diary import TravelDiary
 from pilgrim.models.photo import Photo
@@ -62,3 +65,23 @@ def session_with_photos(session_with_one_diary):
     session.commit()
 
     return session, [photo1, photo2]
+
+@pytest.fixture
+def entry_with_photo_references(session_with_one_diary):
+    session, diary = session_with_one_diary
+    photo1 = Photo(filepath="p1.jpg", name="P1", photo_hash="aaaaaaaa", fk_travel_diary_id=diary.id)
+    photo2 = Photo(filepath="p2.jpg", name="P2", photo_hash="bbbbbbbb", fk_travel_diary_id=diary.id)
+    session.add_all([photo1, photo2])
+    session.flush()
+    entry = Entry(
+        title="Entrada com Fotos",
+        text="Texto com a foto A [[photo::aaaaaaaa]] e também a foto B [[photo::bbbbbbbb]].",
+        date=datetime.now(),
+        travel_diary_id=diary.id,
+        photos=[photo1, photo2]
+    )
+    session.add(entry)
+    session.commit()
+    session.refresh(entry)
+
+    return session, entry


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test fixture to support entries with embedded photo references.
  * Introduced tests to verify correct deletion of photo references from entry text, including handling of specific, non-existent, and truncated photo hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->